### PR TITLE
fix: Add error check for missing matrix file

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -30,6 +30,7 @@
 #include <string.h>
 #include <stdarg.h>
 #include <limits.h>
+#include <errno.h>
 //#include "ksw2/kalloc.h"
 #include "ksw2/kseq.h"
 #include "ksw2/ksw2.h"
@@ -79,6 +80,10 @@ unsigned char seq_nt4_table[256] = {
 
 void fill_matrix(int8_t *matrix, char *fn) {
 	FILE *fp = fopen(fn, "r");
+	if (fp == NULL) {
+		fprintf(stderr, "Error: Cannot open matrix file '%s': %s\n", fn, strerror(errno));
+		exit(1);
+	}
 	char buffer[256];
 	char *pch;
 	int i = 0;

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -69,6 +69,22 @@ echo "Testing matrix loading with 5x5 matrix (-m)";
 echo "args: -m tests/matrix_5x5.txt" >> $output;
 echo -e "GATTAC\nGATTAC" | $script_dir/../ksw -m $script_dir/matrix_5x5.txt >> $output;
 
+# Test error handling for missing matrix file (Issue #18)
+echo "Testing error handling for missing matrix file (-m)";
+set +e
+error_output=$($script_dir/../ksw -m /nonexistent/matrix.txt 2>&1);
+exit_status=$?;
+set -e
+if [ $exit_status -eq 0 ]; then
+    echo "FAIL: Expected non-zero exit status for missing matrix file";
+    exit 1;
+fi
+if [[ "$error_output" != *"Cannot open matrix file"* ]]; then
+    echo "FAIL: Expected error message for missing matrix file, got: $error_output";
+    exit 1;
+fi
+echo "PASS: Missing matrix file error handling";
+
 # Check test output
 if [ "$overwrite" == "0" ]; then
     diff $actual $expected;


### PR DESCRIPTION
## Summary

- Add NULL check after `fopen()` in `fill_matrix()` to prevent segfault
- Display helpful error message when matrix file is missing/unreadable
- Add test for error handling behavior

## Details

Previously, if a user specified a non-existent matrix file with `-m`, the program would segfault. Now it displays:
```
Error: Cannot open matrix file '/path/to/file'
```

## Test plan

- [x] Build on Mac ARM64
- [x] Run `make test` - all tests pass
- [x] Verify error message for missing file: `./ksw -m /nonexistent.txt`

Fixes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when required matrix files cannot be opened: the program now prints a clear error message and exits with a non-zero status instead of proceeding with invalid resources.

* **Tests**
  * Added a test confirming the program reports the failure and exits appropriately when a matrix file is missing or inaccessible.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->