### PR TITLE
fix: Add bounds check for empty string newline removal

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -530,8 +530,8 @@ void align(char *query, char *target, main_opt_t *opt, alignment_t *alignment)
 	int tl = strlen(target); // target length
 
 	// remove ending newlines
-	if (query[ql-1] == '\n') { query[ql-1] = '\0'; ql--; }
-	if (target[tl-1] == '\n') { target[tl-1] = '\0'; tl--; }
+	if (ql > 0 && query[ql-1] == '\n') { query[ql-1] = '\0'; ql--; }
+	if (tl > 0 && target[tl-1] == '\n') { target[tl-1] = '\0'; tl--; }
 
 	// reset the alignment
 	alignment_reset(alignment);


### PR DESCRIPTION
## Summary

Add length guards before accessing `query[ql-1]` and `target[tl-1]` to prevent undefined behavior when input strings are empty.

## Test plan

- [x] Build and run `make test`

Fixes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a potential crash when processing empty inputs in string alignment operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->