### PR TITLE
chore: Add CodeRabbit configuration

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+# Disable docstring coverage check - not relevant for C projects
+pre_merge_checks:
+  docstrings:
+    mode: "off"


### PR DESCRIPTION
## Summary

- Disable docstring coverage check which is not relevant for C projects

This removes the warning that appears on every PR:
> Docstring coverage is 0.00% which is insufficient. The required threshold is 80.00%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)