### PR TITLE
fix: make the bundled parasail build robust (lib-only + parallel-safe)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,9 @@ KSW2_SRCS=    $(filter-out $(KSW2_MAINS),$(wildcard $(KSW2_SRC_DIR)/*c))
 KSW2_OBJS=    $(KSW2_SRCS:$(KSW2_SRC_DIR)/%.c=$(KSW2_OBJ_DIR)/%.o)
 
 PROG=		  ksw
-SUBDIRS=      $(SRC_DIR)/ksw2/ $(SRC_DIR)/parasail/build
+KSW2_BUILD=     $(SRC_DIR)/ksw2/
+PARASAIL_BUILD= $(SRC_DIR)/parasail/build
+SUBDIRS=      $(KSW2_BUILD) $(PARASAIL_BUILD)
 
 CC=			  gcc
 CFLAGS=		  -g -Wall -Wno-unused-function -O2
@@ -55,8 +57,16 @@ endif
 
 all: $(SUBDIRS) $(PROG)
 
-$(SUBDIRS): $(SRC_DIR)/ksw2/Makefile $(SRC_DIR)/parasail/build/Makefile 
+# ksw2 builds its default target. parasail builds only its `parasail` static
+# library target rather than the default `all`, which would also compile the
+# bundled test and app executables. Those tests are not needed to link ksw and
+# fail to compile under stricter compilers (e.g. GCC 14, which promotes
+# -Wincompatible-pointer-types to a hard error in parasail's test sources).
+$(KSW2_BUILD): $(SRC_DIR)/ksw2/Makefile
 	$(MAKE) aarch64=$(aarch64) arm_neon=$(arm_neon) -C $@
+
+$(PARASAIL_BUILD): $(SRC_DIR)/parasail/build/Makefile
+	$(MAKE) aarch64=$(aarch64) arm_neon=$(arm_neon) -C $@ parasail
 
 ksw: $(KSW2_OBJS) $(OBJS) $(SRC_DIR)/parasail/build/libparasail.a
 	$(CC) -g $(LDFLAGS) $(DFLAGS) $(KSW2_OBJS) $(OBJS) $(LIBS) -o $@

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,11 @@ $(KSW2_BUILD): $(SRC_DIR)/ksw2/Makefile
 $(PARASAIL_BUILD): $(SRC_DIR)/parasail/build/Makefile
 	$(MAKE) aarch64=$(aarch64) arm_neon=$(arm_neon) -C $@ parasail
 
-ksw: $(KSW2_OBJS) $(OBJS) $(SRC_DIR)/parasail/build/libparasail.a
+# The order-only prerequisite on the subdirectories ensures ksw2 and parasail
+# (which produce $(KSW2_OBJS) and libparasail.a) are fully built before ksw is
+# linked. Without it, `make -j` can start linking ksw before libparasail.a
+# exists (ld: cannot find -lparasail).
+ksw: $(KSW2_OBJS) $(OBJS) $(SRC_DIR)/parasail/build/libparasail.a | $(SUBDIRS)
 	$(CC) -g $(LDFLAGS) $(DFLAGS) $(KSW2_OBJS) $(OBJS) $(LIBS) -o $@
 
 $(OBJ_DIR)/%.o: $(SRC_DIR)/%.c $(SRC_DIR)/githash.h


### PR DESCRIPTION
## Summary

Two related fixes to how ksw builds its bundled [parasail](https://github.com/jeffdaily/parasail) submodule. Both surfaced while getting the ksw 0.3.0 bioconda build green (bioconda/bioconda-recipes#64746).

### 1. Build only the parasail library, not its tests and apps

ksw builds parasail's default `all` CMake target, which compiles parasail's full suite of test/app executables (`test_*`, `parasail_aligner`, `parasail_stats`, `traceback`). ksw only links `libparasail.a`, so those are dead weight — and one of them, `tests/test_verify_traces.c`, assigns an `int *` to an `int8_t *`. GCC 14+ promotes `-Wincompatible-pointer-types` to a hard error by default, so the bundled test fails to compile and takes the whole build down with it.

Build only parasail's `parasail` static-library target instead. ksw2 still builds its default target.

### 2. Link ksw only after the subdirectories are built

`all: $(SUBDIRS) $(PROG)` let a parallel `make -j` start linking `ksw` before `libparasail.a` had been built, failing with `ld: cannot find -lparasail`. Add an order-only prerequisite on `$(SUBDIRS)` to the `ksw` target so the subdirectories (which produce `$(KSW2_OBJS)` and `libparasail.a`) are complete before linking.

## Validation

Building the parasail subdir produces `libparasail.a` and no test/app executables, and a dry-run parses cleanly:

```
$ make src/parasail/build
$ ls src/parasail/build | grep -E 'libparasail|test_|parasail_aligner'
libparasail.a
```

## Note on CMake 4

Separately, parasail's pre-CMake-4 feature-detection modules (`cmake/FindSSE41.cmake`, etc.) fail to configure under CMake 4 (`CMAKE_C_COMPILER not set, after EnableLanguage` in `try_compile`). That's a parasail-level issue; the bioconda recipe pins `cmake <4` to work around it. Not addressed here.